### PR TITLE
test.linked.data.gov.au -> linked.data.gov.au

### DIFF
--- a/crs-th.ttl
+++ b/crs-th.ttl
@@ -1,4 +1,4 @@
-@prefix : <http://test.linked.data.gov.au/def/crs-th/> .
+@prefix : <http://linked.data.gov.au/def/crs-th/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .


### PR DESCRIPTION
Removed the temporary PID URI since NAA has now minted the real one for the CRS Th.